### PR TITLE
Allow specifying proxy url's with trailing slash 

### DIFF
--- a/telegroam.js
+++ b/telegroam.js
@@ -294,7 +294,6 @@ async function updateFromTelegram () {
             })
 
             console.log("fetching", url, "from proxy")
-            let proxiedUrl = 
             let blobResponse = await fetch(
               `${corsProxyUrl}/${url}`
             )

--- a/telegroam.js
+++ b/telegroam.js
@@ -56,6 +56,7 @@ function stripTrailingSlash (url) {
     return url.slice(0, -1)
   } else {
     return url
+  }
 }
 
 async function updateFromTelegram () {

--- a/telegroam.js
+++ b/telegroam.js
@@ -51,8 +51,15 @@ function formatTime (unixSeconds) {
   return hhmm
 }
 
+function stripTrailingSlash (url) {
+  if (url.endsWith('/')) {
+    return url.slice(0, -1)
+  } else {
+    return url
+}
+
 async function updateFromTelegram () {
-  let corsProxyUrl = findBotAttribute("Trusted Media Proxy").value
+  let corsProxyUrl = stripTrailingSlash(findBotAttribute("Trusted Media Proxy").value)
 
   let apiKey = findBotAttribute("API Key").value
   let api = `https://api.telegram.org/bot${apiKey}`
@@ -287,6 +294,7 @@ async function updateFromTelegram () {
             })
 
             console.log("fetching", url, "from proxy")
+            let proxiedUrl = 
             let blobResponse = await fetch(
               `${corsProxyUrl}/${url}`
             )


### PR DESCRIPTION
Currently if the proxy url given in `Trusted Media Proxy::` has a trailing slash, media won't upload and will be stuck at "Uploading in progress: …".

Tested (manually in my graph).