### PR TITLE
change from hiccup audio to [[audio]]

### DIFF
--- a/telegroam.js
+++ b/telegroam.js
@@ -329,7 +329,7 @@
         }
 
         let photo = url => `![photo](${url})`
-        let audio = url => `:hiccup[:audio {:controls true :src "${url}"}]`
+        let audio = url => `{{[[audio]]:${url}}}`
         let video = url => `:hiccup[:video {:controls true :src "${url}"}]`
 
         if (message.sticker) {


### PR DESCRIPTION
Switching from `:hiccup` (which is kind of a hack and may not always be supported) to Roam's native audio command `{{[[audio]]: URL_HERE}}`